### PR TITLE
use node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,5 +9,5 @@ inputs:
     required: true
     default: '15.12.0'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'build/index.js'


### PR DESCRIPTION
I'm getting a warning in my workflow runs that setup-lix is requesting node16 but being forced to use node20 because github actions is forcing that change. If this is the correct way to bump the node version, I hope this gets rid of that warning message.